### PR TITLE
Correctly publish ChangeChannelEvent with new channel IDs (#4174)

### DIFF
--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -203,6 +203,10 @@ export class ChannelService {
             id => !assignedChannels.some(ec => idsAreEqual(ec.channelId, id)),
         );
 
+        if (!newChannelIds.length) {
+            return entity;
+        }
+
         await this.connection
             .getRepository(ctx, entityType)
             .createQueryBuilder()
@@ -210,7 +214,9 @@ export class ChannelService {
             .of(entity.id)
             .add(newChannelIds);
 
-        await this.eventBus.publish(new ChangeChannelEvent(ctx, entity, channelIds, 'assigned', entityType));
+        await this.eventBus.publish(
+            new ChangeChannelEvent(ctx, entity, newChannelIds, 'assigned', entityType),
+        );
         return entity;
     }
 
@@ -249,7 +255,9 @@ export class ChannelService {
             .relation('channels')
             .of(entity.id)
             .remove(existingChannelIds);
-        await this.eventBus.publish(new ChangeChannelEvent(ctx, entity, channelIds, 'removed', entityType));
+        await this.eventBus.publish(
+            new ChangeChannelEvent(ctx, entity, existingChannelIds, 'removed', entityType),
+        );
         return entity;
     }
 


### PR DESCRIPTION
# Description

Correctly publish ChangeChannelEvent with new channel IDs.
Fixes #4174

# Breaking changes

No - Except someone was relying on this event to actually track `assignToChannels` function calls instead of new channels being assigned

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
